### PR TITLE
Remove transaction table synchronization

### DIFF
--- a/client/src/app/dashboard/transactions/data-table.tsx
+++ b/client/src/app/dashboard/transactions/data-table.tsx
@@ -56,10 +56,6 @@ const DataTable = <TData, TValue>({
   ]);
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
 
-  React.useEffect(() => {
-    setTableData(data);
-  }, [data]);
-
   const queryClient = useQueryClient();
   const { mutate, isPending } = useMutation({
     mutationFn: async (newTransaction: Transaction) => {


### PR DESCRIPTION
I was using useEffect to synchronize the table with the backend after edits. This was causing a re-render which screws up my table state. It's not really expected for that stuff to auto-update, so I'll just remove it. The expected behavior now is for the table to update on refresh.