### PR TITLE
Filter out very small transactions from budgets

### DIFF
--- a/client/src/app/budget/unbudgets.tsx
+++ b/client/src/app/budget/unbudgets.tsx
@@ -51,7 +51,9 @@ const getUnbudgetedTransactions = (budgets: Budget[], transactions: Transaction[
     });
   });
 
-  return unbudgetedTransactions;
+  // Transfers can have two transactions that cancel each other out and result in
+  // zero net cash flow. For this reason, filter out any net 0 transactions.
+  return unbudgetedTransactions.filter((u) => u.amount !== 0);
 };
 
 interface UnbudgetProps {

--- a/client/src/app/budget/unbudgets.tsx
+++ b/client/src/app/budget/unbudgets.tsx
@@ -52,8 +52,9 @@ const getUnbudgetedTransactions = (budgets: Budget[], transactions: Transaction[
   });
 
   // Transfers can have two transactions that cancel each other out and result in
-  // zero net cash flow. For this reason, filter out any net 0 transactions.
-  return unbudgetedTransactions.filter((u) => u.amount !== 0);
+  // zero net cash flow. For this reason, filter out any net 0 transactions categories.
+  // Also filtering very small transactions categories (less than $1) to reduce clutter.
+  return unbudgetedTransactions.filter((u) => Math.abs(u.amount) > 1);
 };
 
 interface UnbudgetProps {


### PR DESCRIPTION
Transaction categories less than 1 cause clutter and can be filtered.