### PR TITLE
Add dark mode select

### DIFF
--- a/client/src/app/auth/account-settings/account-settings.tsx
+++ b/client/src/app/auth/account-settings/account-settings.tsx
@@ -1,6 +1,7 @@
 import { SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import LinkSimpleFin from './link-simplefin';
 import ResetPassword from './reset-password';
+import DarkModeToggle from './dark-mode-toggle';
 
 const AccountSettings = (): JSX.Element => {
   return (
@@ -9,6 +10,7 @@ const AccountSettings = (): JSX.Element => {
         <SheetTitle>Account</SheetTitle>
         <SheetDescription>Make changes to your account here.</SheetDescription>
       </SheetHeader>
+      <DarkModeToggle />
       <LinkSimpleFin />
       <ResetPassword />
     </div>

--- a/client/src/app/auth/account-settings/dark-mode-toggle.tsx
+++ b/client/src/app/auth/account-settings/dark-mode-toggle.tsx
@@ -1,0 +1,30 @@
+import { useTheme } from '@/components/theme-provider';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const DarkModeToggle = (): JSX.Element => {
+  const { setTheme, theme } = useTheme();
+
+  return (
+    <div className="flex flex-col space-y-2 p-2">
+      <span>Visual Appearance</span>
+      <Select onValueChange={setTheme} defaultValue={theme}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select a theme" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="light">Light</SelectItem>
+          <SelectItem value="dark">Dark</SelectItem>
+          <SelectItem value="system">System</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export default DarkModeToggle;

--- a/client/src/app/auth/header.tsx
+++ b/client/src/app/auth/header.tsx
@@ -6,9 +6,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { firebaseAuth } from '@/lib/firebase';
-import { DropdownMenuTrigger } from '@radix-ui/react-dropdown-menu';
 import { useQueryClient } from '@tanstack/react-query';
 import { signOut } from 'firebase/auth';
 import AccountSettings from './account-settings/account-settings';


### PR DESCRIPTION
Adding a selector for dark mode in accounts settings. Defaults to system and stores the value in local storage. Because of this, it won't persist across devices, but probably not a big deal since it defaults to system.