### PR TITLE
Add pagination to uncategorized transactions

### DIFF
--- a/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
+++ b/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
@@ -29,7 +29,7 @@ const PageIterator = (props: PageIteratorProps): JSX.Element => {
       <Button className="p-2" variant="ghost" onClick={() => changePage(props.page - 1)}>
         <ChevronLeftIcon />
       </Button>
-      <div className="text-lg font-semibold">
+      <div className="font-semibold">
         Page {props.page} of {props.maxPages}
       </div>
       <Button className="p-2" variant="ghost" onClick={() => changePage(props.page + 1)}>

--- a/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
+++ b/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+
+interface PageIteratorProps {
+  className?: string;
+  page: number;
+  setPage: (page: number) => void;
+}
+
+const PageIterator = (props: PageIteratorProps): JSX.Element => {
+  return (
+    <div
+      className={cn(
+        'flex flex-row items-center justify-center space-x-1',
+        props.className
+      )}
+    >
+      <Button
+        className="p-2"
+        variant="ghost"
+        onClick={() => props.setPage(props.page - 1)}
+      >
+        <ChevronLeftIcon />
+      </Button>
+      <div className="text-lg font-semibold">Page {props.page}</div>
+      <Button
+        className="p-2"
+        variant="ghost"
+        onClick={() => props.setPage(props.page + 1)}
+      >
+        <ChevronRightIcon />
+      </Button>
+    </div>
+  );
+};
+
+export default PageIterator;

--- a/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
+++ b/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
@@ -5,10 +5,20 @@ import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 interface PageIteratorProps {
   className?: string;
   page: number;
+  maxPages: number;
   setPage: (page: number) => void;
 }
 
 const PageIterator = (props: PageIteratorProps): JSX.Element => {
+  const changePage = (newPage: number) => {
+    if (newPage < 1) {
+      props.setPage(props.maxPages);
+    } else if (newPage > props.maxPages) {
+      props.setPage(1);
+    } else {
+      props.setPage(newPage);
+    }
+  };
   return (
     <div
       className={cn(
@@ -16,19 +26,13 @@ const PageIterator = (props: PageIteratorProps): JSX.Element => {
         props.className
       )}
     >
-      <Button
-        className="p-2"
-        variant="ghost"
-        onClick={() => props.setPage(props.page - 1)}
-      >
+      <Button className="p-2" variant="ghost" onClick={() => changePage(props.page - 1)}>
         <ChevronLeftIcon />
       </Button>
-      <div className="text-lg font-semibold">Page {props.page}</div>
-      <Button
-        className="p-2"
-        variant="ghost"
-        onClick={() => props.setPage(props.page + 1)}
-      >
+      <div className="text-lg font-semibold">
+        Page {props.page} of {props.maxPages}
+      </div>
+      <Button className="p-2" variant="ghost" onClick={() => changePage(props.page + 1)}>
         <ChevronRightIcon />
       </Button>
     </div>

--- a/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
+++ b/client/src/app/auth/tabs/dashboard/uncategorized-transactions/page-iterator.tsx
@@ -19,6 +19,12 @@ const PageIterator = (props: PageIteratorProps): JSX.Element => {
       props.setPage(newPage);
     }
   };
+
+  // Page selector not needed if we only have a single page
+  if (props.maxPages === 1) {
+    return <></>;
+  }
+
   return (
     <div
       className={cn(

--- a/client/src/components/category-input.tsx
+++ b/client/src/components/category-input.tsx
@@ -24,7 +24,7 @@ const CategoryInput = (props: CategoryInputProps): JSX.Element => {
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState(props.initialValue);
 
-  const categoriesTree = getCategoriesAsTree();
+  const categoriesTree = React.useMemo(getCategoriesAsTree, []);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
When there are hundreds of transactions, the tab can get laggy. Adding pagination to limit to 50 for now. May update later to allow you to set the number per page