### PR TITLE
Fix Error with Chart

### DIFF
--- a/client/src/app/auth/tabs/dashboard/spending-trends/spending-trends-card.tsx
+++ b/client/src/app/auth/tabs/dashboard/spending-trends/spending-trends-card.tsx
@@ -64,7 +64,8 @@ const SpendingTrendsCard = (): JSX.Element => {
     const today = new Date().getDate();
 
     return (
-      thisMonthRollingTotal[today - 1].amount - lastMonthRollingTotal[today - 1].amount
+      (thisMonthRollingTotal.at(today - 1)?.amount ?? 0) -
+      (lastMonthRollingTotal.at(today - 1)?.amount ?? 0)
     );
   };
 


### PR DESCRIPTION
There was an error with the spending chart when transactions were empty. Fixed it.