### PR TITLE
Set Max Height of Spending Chart

### DIFF
--- a/client/src/app/auth/tabs/dashboard/spending-trends/spending-trends-chart.tsx
+++ b/client/src/app/auth/tabs/dashboard/spending-trends/spending-trends-chart.tsx
@@ -74,7 +74,7 @@ const SpendingTrendsChart = (props: SpendingTrendsChartProps): JSX.Element => {
 
   return (
     <div>
-      <ChartContainer config={chartConfig}>
+      <ChartContainer config={chartConfig} className="max-h-[400px] w-full">
         <AreaChart data={getChartData()}>
           <XAxis dataKey="day" tickLine={false} axisLine={false} />
           <ChartTooltip content={<ChartTooltipContent />} />


### PR DESCRIPTION
Chart is too big when left to the default size. Setting a max height.