### PR TITLE
adjust cron schedule

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -133,7 +133,7 @@ if (!builder.Configuration.GetValue<bool>("DISABLE_AUTO_SYNC"))
                 // Allow a minute for everything to settle after boot before starting the job
                 .StartAt(DateBuilder.FutureDate(1, IntervalUnit.Minute))
                 // Every day at 5am and 5pm
-                .WithCronSchedule("0 5,17 * * * ?"));
+                .WithCronSchedule("0 0 5,17 * * ?"));
     });
 
     builder.Services.AddQuartzHostedService(options =>


### PR DESCRIPTION
Quartz uses cron expressions of the form:

```
    1. Seconds
    2. Minutes
    3. Hours
    4. Day-of-Month
    5. Month
    6. Day-of-Week
    7. Year (optional field)
```

Need to update the seconds so this runs at the right time.