### PR TITLE
Update trends graph skeletons

### DIFF
--- a/client/src/app/auth/pages/trends/assets/asset-graph.tsx
+++ b/client/src/app/auth/pages/trends/assets/asset-graph.tsx
@@ -83,29 +83,17 @@ const AssetsGraph = (): JSX.Element => {
     selectedAccountIds
   );
 
-  if (balancesQuery.isPending || accountsQuery.isPending) {
-    return (
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-[40px] w-full max-w-[300px]" />
-        <Skeleton className="aspect-video max-h-[400px] w-full" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      <AccountsGraphHeader
-        selectedAccountIds={selectedAccountIds}
-        setSelectedAccountIds={setSelectedAccountIds}
-        dateRange={dateRange}
-        setDateRange={setDateRange}
-        filters={['Checking', 'Savings', 'Investment', 'Cash']}
-      />
-      {selectedAccountIds.length === 0 ? (
+  const conditionalRender = (): JSX.Element => {
+    if (balancesQuery.isPending || accountsQuery.isPending) {
+      return <Skeleton className="aspect-video max-h-[400px] w-full" />;
+    } else if (selectedAccountIds.length === 0) {
+      return (
         <div className="flex aspect-video max-h-[400px] w-full items-center justify-center">
           <span className="text-center">Select an account to display the chart.</span>
         </div>
-      ) : (
+      );
+    } else {
+      return (
         <ChartContainer config={chartConfig} className="max-h-[400px] w-full">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={true} />
@@ -183,7 +171,20 @@ const AssetsGraph = (): JSX.Element => {
             ))}
           </BarChart>
         </ChartContainer>
-      )}
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <AccountsGraphHeader
+        selectedAccountIds={selectedAccountIds}
+        setSelectedAccountIds={setSelectedAccountIds}
+        dateRange={dateRange}
+        setDateRange={setDateRange}
+        filters={['Checking', 'Savings', 'Investment', 'Cash']}
+      />
+      {conditionalRender()}
     </div>
   );
 };

--- a/client/src/app/auth/pages/trends/liabilities/liabilities-graph.tsx
+++ b/client/src/app/auth/pages/trends/liabilities/liabilities-graph.tsx
@@ -84,29 +84,17 @@ const LiabilitiesGraph = (): JSX.Element => {
     selectedAccountIds
   );
 
-  if (balancesQuery.isPending || accountsQuery.isPending) {
-    return (
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-[40px] w-full max-w-[300px]" />
-        <Skeleton className="aspect-video max-h-[400px] w-full" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      <AccountsGraphHeader
-        selectedAccountIds={selectedAccountIds}
-        setSelectedAccountIds={setSelectedAccountIds}
-        dateRange={dateRange}
-        setDateRange={setDateRange}
-        filters={['Loan', 'Credit Card', 'Mortgage']}
-      />
-      {selectedAccountIds.length === 0 ? (
+  const conditionalRender = (): JSX.Element => {
+    if (balancesQuery.isPending || accountsQuery.isPending) {
+      return <Skeleton className="aspect-video max-h-[400px] w-full" />;
+    } else if (selectedAccountIds.length === 0) {
+      return (
         <div className="flex aspect-video max-h-[400px] w-full items-center justify-center">
           <span className="text-center">Select an account to display the chart.</span>
         </div>
-      ) : (
+      );
+    } else {
+      return (
         <ChartContainer config={chartConfig} className="max-h-[400px] w-full">
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={true} />
@@ -184,7 +172,20 @@ const LiabilitiesGraph = (): JSX.Element => {
             ))}
           </BarChart>
         </ChartContainer>
-      )}
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <AccountsGraphHeader
+        selectedAccountIds={selectedAccountIds}
+        setSelectedAccountIds={setSelectedAccountIds}
+        dateRange={dateRange}
+        setDateRange={setDateRange}
+        filters={['Loan', 'Credit Card', 'Mortgage']}
+      />
+      {conditionalRender()}
     </div>
   );
 };

--- a/client/src/app/auth/pages/trends/net-cash-flow/net-cash-flow-graph.tsx
+++ b/client/src/app/auth/pages/trends/net-cash-flow/net-cash-flow-graph.tsx
@@ -72,6 +72,7 @@ const NetCashFlowGraph = () => {
     net: number;
   }
 
+  const monthButtons = [3, 6, 12];
   const sortedMonths = selectedMonths.sort((a, b) => a.getTime() - b.getTime());
 
   const BuildChartData = (): ChartDatum[] => {
@@ -121,60 +122,17 @@ const NetCashFlowGraph = () => {
     },
   } satisfies ChartConfig;
 
-  if (transactionsQuery.isPending) {
-    return (
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-[62px] w-full" />
-        <Skeleton className="aspect-video max-h-[400px] w-full" />
-      </div>
-    );
-  }
-
-  const monthButtons = [3, 6, 12];
-
-  return (
-    <div className="flex w-full flex-col gap-4">
-      <MonthToolCards
-        selectedDates={selectedMonths}
-        setSelectedDates={setSelectedMonths}
-        timeToMonthlyTotalsMap={buildTimeToMonthlyTotalsMap(
-          selectedMonths,
-          transactionsWithoutHidden
-        )}
-        showCopy={false}
-        isPending={false}
-        allowSelectMultiple={true}
-      />
-      <div className="flex w-full flex-row flex-wrap justify-end gap-2">
-        {monthButtons.map((months) => (
-          <Button
-            size="sm"
-            variant="outline"
-            key={months}
-            onClick={() => {
-              // Clear prior to adding new months to prevent duplicates.
-              setSelectedMonths([]);
-              for (let i = 0; i < months; i++) {
-                setSelectedMonths((prev) => {
-                  const newMonths = [...prev];
-                  newMonths.push(getDateFromMonthsAgo(i));
-                  return newMonths;
-                });
-              }
-            }}
-          >
-            Last {months} Months
-          </Button>
-        ))}
-        <Button size="sm" onClick={() => setSelectedMonths([])}>
-          Clear
-        </Button>
-      </div>
-      {selectedMonths.length === 0 ? (
+  const conditionalRender = (): JSX.Element => {
+    if (transactionsQuery.isPending) {
+      return <Skeleton className="aspect-video max-h-[400px] w-full" />;
+    } else if (selectedMonths.length === 0) {
+      return (
         <div className="flex aspect-video max-h-[400px] w-full items-center justify-center">
           <span className="text-center">Select an account to display the chart.</span>
         </div>
-      ) : (
+      );
+    } else {
+      return (
         <ChartContainer config={chartConfig} className="max-h-[400px] w-full">
           <ComposedChart accessibilityLayer data={chartData} stackOffset="sign">
             <CartesianGrid vertical={true} />
@@ -259,7 +217,49 @@ const NetCashFlowGraph = () => {
             />
           </ComposedChart>
         </ChartContainer>
-      )}
+      );
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <MonthToolCards
+        selectedDates={selectedMonths}
+        setSelectedDates={setSelectedMonths}
+        timeToMonthlyTotalsMap={buildTimeToMonthlyTotalsMap(
+          selectedMonths,
+          transactionsWithoutHidden
+        )}
+        showCopy={false}
+        isPending={false}
+        allowSelectMultiple={true}
+      />
+      <div className="flex w-full flex-row flex-wrap justify-end gap-2">
+        {monthButtons.map((months) => (
+          <Button
+            size="sm"
+            variant="outline"
+            key={months}
+            onClick={() => {
+              // Clear prior to adding new months to prevent duplicates.
+              setSelectedMonths([]);
+              for (let i = 0; i < months; i++) {
+                setSelectedMonths((prev) => {
+                  const newMonths = [...prev];
+                  newMonths.push(getDateFromMonthsAgo(i));
+                  return newMonths;
+                });
+              }
+            }}
+          >
+            Last {months} Months
+          </Button>
+        ))}
+        <Button size="sm" onClick={() => setSelectedMonths([])}>
+          Clear
+        </Button>
+      </div>
+      {conditionalRender()}
     </div>
   );
 };

--- a/client/src/app/auth/pages/trends/net-worth/net-worth-graph.tsx
+++ b/client/src/app/auth/pages/trends/net-worth/net-worth-graph.tsx
@@ -89,28 +89,17 @@ const NetWorthGraph = (): JSX.Element => {
     },
   } satisfies ChartConfig;
 
-  if (balancesQuery.isPending || accountsQuery.isPending) {
-    return (
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-[40px] w-full max-w-[300px]" />
-        <Skeleton className="aspect-video max-h-[400px] w-full" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      <AccountsGraphHeader
-        selectedAccountIds={selectedAccountIds}
-        setSelectedAccountIds={setSelectedAccountIds}
-        dateRange={dateRange}
-        setDateRange={setDateRange}
-      />
-      {selectedAccountIds.length === 0 ? (
+  const conditionalRender = (): JSX.Element => {
+    if (balancesQuery.isPending || accountsQuery.isPending) {
+      return <Skeleton className="aspect-video max-h-[400px] w-full" />;
+    } else if (selectedAccountIds.length === 0) {
+      return (
         <div className="flex aspect-video max-h-[400px] w-full items-center justify-center">
           <span className="text-center">Select an account to display the chart.</span>
         </div>
-      ) : (
+      );
+    } else {
+      return (
         <ChartContainer config={chartConfig} className="max-h-[400px] w-full">
           <ComposedChart accessibilityLayer data={chartData} stackOffset="sign">
             <CartesianGrid vertical={true} />
@@ -193,7 +182,19 @@ const NetWorthGraph = (): JSX.Element => {
             />
           </ComposedChart>
         </ChartContainer>
-      )}
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <AccountsGraphHeader
+        selectedAccountIds={selectedAccountIds}
+        setSelectedAccountIds={setSelectedAccountIds}
+        dateRange={dateRange}
+        setDateRange={setDateRange}
+      />
+      {conditionalRender()}
     </div>
   );
 };


### PR DESCRIPTION
The skeletons for the trends cards included the header, so when a new option was selected, it would re-render it and close the current drop down. This was annoying when you wanted to click multiple, so I changed the skeleton to only include the actual graph itself.