### PR TITLE
Fix the number of days for the month

### DIFF
--- a/client/src/app/Authorized/PageContent/Dashboard/SpendingTrendsCard/SpendingTrendsCard.tsx
+++ b/client/src/app/Authorized/PageContent/Dashboard/SpendingTrendsCard/SpendingTrendsCard.tsx
@@ -75,6 +75,18 @@ const SpendingTrendsCard = (): React.ReactNode => {
       getDaysInMonth(months[1]?.getMonth() ?? 0, months[1]?.getFullYear() ?? 0)
     );
 
+    if (
+      today >
+      getDaysInMonth(months[1]?.getMonth() ?? 0, months[1]?.getFullYear() ?? 0)
+    ) {
+      // If today is greater than the last day of the last month, we need to compare to the
+      // last day of the last month.
+      return (
+        (thisMonthRollingTotal.at(today - 1)?.amount ?? 0) -
+        (lastMonthRollingTotal.at(-1)?.amount ?? 0)
+      );
+    }
+
     return (
       (thisMonthRollingTotal.at(today - 1)?.amount ?? 0) -
       (lastMonthRollingTotal.at(today - 1)?.amount ?? 0)

--- a/client/src/helpers/datetime.ts
+++ b/client/src/helpers/datetime.ts
@@ -98,12 +98,13 @@ export const getUniqueYears = (dates: Date[]): number[] =>
 /**
  * Returns the total number of days in a specified month and year.
  *
- * @param {number} month - The month (1-12).
+ * @param {number} monthIndex - The month index (0-11).
  * @param {number} year - The full year (e.g., 2023).
  * @returns {number} The number of days in the given month of that year.
  */
-export const getDaysInMonth = (month: number, year: number): number =>
-  new Date(year, month, 0).getDate();
+export const getDaysInMonth = (monthIndex: number, year: number): number =>
+  // Setting the date to 0 of the next month gives us the last day of the current month.
+  new Date(year, monthIndex + 1, 0).getDate();
 
 /**
  * Returns a localized month and year string for the provided date.


### PR DESCRIPTION
- Fixed account charts to display the correct number of days for the month.
- Fixed the spending difference to stop at the last day of the last month if the previous month has less days.